### PR TITLE
Automatically detect VCF files as VCards

### DIFF
--- a/ftdetect/vcard.vim
+++ b/ftdetect/vcard.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.vcf              set filetype=vcard

--- a/syntax/vcard.vim
+++ b/syntax/vcard.vim
@@ -36,9 +36,9 @@ syn match VCStatement	"^BEGIN:VCARD.*$"
 syn match VCStatement	"^END:VCARD.*$"
 syn match VCStatement	"^.*VERSION:.*$"
 
-"syn region  basicString		start=+"+  end=+"+  
-"syn region  basicString		start=+'+  end=+'+  
-"syn region  basicString		start=+\\+  end=+\\+  
+"syn region  basicString		start=+"+  end=+"+
+"syn region  basicString		start=+'+  end=+'+
+"syn region  basicString		start=+\\+  end=+\\+
 
 "syn region  basicComment	start="REM\s" end="$" contains=basicTodo
 "syn region  basicComment	start="*" end="$" contains=basicTodo


### PR DESCRIPTION
I found Lubomir Husar's script useful with these two small changes and am publishing them for others to use.

http://www.vim.org/scripts/script.php?script_id=1455 has not been maintained since 2006-02-02 and I tried contacting the original author at both the address published on [vim.org](http://www.vim.org/account/profile.php?user_id=7258) and the one [in the script](https://github.com/vim-scripts/VCard-syntax/blob/master/syntax/vcard.vim#L3). Since neither address is receiving email, I don't expect this PR to ever be merged.
